### PR TITLE
More generic instances, and easier instance definition

### DIFF
--- a/src/main/scala/filter.scala
+++ b/src/main/scala/filter.scala
@@ -1,3 +1,4 @@
+import slick.ast.BaseTypedType
 import slick.driver.H2Driver.api._
 import scala.language.higherKinds
 
@@ -8,8 +9,9 @@ object Filters {
   //
   sealed trait Comparison {
     // A comparison can filter if there is a "where builder" for the types involved
-    def filter[M,U,C[_],T,R](v: T, q: Query[M,U,C])(column: M => Rep[R])(implicit where: WhereBuilder[R,T]): Option[Query[M,U,C]] = 
-      where(column, this, v, q)
+    def filter[M, U, C[_], T, R](v: T, q: Query[M, U, C])(column: M => Rep[R])
+      (implicit where: WhereBuilder[R, T]): Option[Query[M, U, C]] = 
+        where(column, v, q).lift(this)
   }
   case object EQ   extends Comparison
   case object NEQ  extends Comparison
@@ -29,44 +31,86 @@ object Filters {
   // in this example, where None indicates we don't allow that kind of 
   // comparison.
   //
-  sealed trait WhereBuilder[R,T] {
-    def apply[M,U,C[_]](column: M => Rep[R], cmp: Comparison, v: T, q: Query[M,U,C]): Option[Query[M,U,C]]
+  trait WhereBuilder[R, -T] {
+    def apply[M, U, C[_]](column: M => Rep[R], v: T, q: Query[M, U, C]): PartialFunction[Comparison, Query[M, U, C]]
   }
 
-  implicit object WhereLong extends WhereBuilder[Long,Long] {
-    def apply[M,U,C[_]](column: M => Rep[Long], cmp: Comparison, v: Long, q: Query[M,U,C]): Option[Query[M,U,C]] =
-      cmp match {
-        case EQ   => Some(q.filter(t => column(t) === v))
-        case NEQ  => Some(q.filter(t => column(t) =!= v))
-        case LTEQ => Some(q.filter(t => column(t)  <= v))
-        case LT   => Some(q.filter(t => column(t)  <  v))
-        case GTEQ => Some(q.filter(t => column(t)  >= v))
-        case GT   => Some(q.filter(t => column(t)  >  v))
-        case IN   => None
-        case LIKE => None
+  class SameTypeWhereBuilder[T: BaseTypedType] extends WhereBuilder[T, T] {
+    def otherOps[M, U, C[_]]
+      (column: M => Rep[T], v: T, q: Query[M, U, C]): PartialFunction[Comparison, Query[M, U, C]] =
+        PartialFunction.empty
+
+    private[this] def sameTypeOps[M, U, C[_]]
+      (column: M => Rep[T], v: T, q: Query[M, U, C]): PartialFunction[Comparison, Query[M, U, C]] = {
+        case EQ   => q.filter(t => column(t) === v): Query[M, U, C]
+        case NEQ  => q.filter(t => column(t) =!= v): Query[M, U, C]
+        case LTEQ => q.filter(t => column(t)  <= v): Query[M, U, C]
+        case LT   => q.filter(t => column(t)  <  v): Query[M, U, C]
+        case GTEQ => q.filter(t => column(t)  >= v): Query[M, U, C]
+        case GT   => q.filter(t => column(t)  >  v): Query[M, U, C]
       }
+
+    final def apply[M, U, C[_]]
+      (column: M => Rep[T], v: T, q: Query[M, U, C]): PartialFunction[Comparison, Query[M, U, C]] =
+        sameTypeOps(column, v, q).orElse(otherOps(column, v, q))
   }
 
-  implicit object WhereLongSeq extends WhereBuilder[Long, List[Long]] {
-    def apply[M,U,C[_]](column: M => Rep[Long], cmp: Comparison, vs: List[Long], q: Query[M,U,C]): Option[Query[M,U,C]] =
-      cmp match {
-        case IN => Some(q.filter(t => column(t) inSetBind vs))
-        case _  => None
+  class OptionWhereBuilder[T: BaseTypedType] extends WhereBuilder[Option[T], T] {
+    def otherOps[M, U, C[_]]
+      (column: M => Rep[Option[T]], v: T, q: Query[M, U, C]): PartialFunction[Comparison, Query[M, U, C]] =
+        PartialFunction.empty
+
+    private[this] def optionOps[M, U, C[_]]
+      (column: M => Rep[Option[T]], v: T, q: Query[M, U, C]): PartialFunction[Comparison, Query[M, U, C]] = {
+        case EQ   => q.filter(t => column(t) === v): Query[M, U, C]
+        case NEQ  => q.filter(t => column(t) =!= v): Query[M, U, C]
+        case LTEQ => q.filter(t => column(t)  <= v): Query[M, U, C]
+        case LT   => q.filter(t => column(t)  <  v): Query[M, U, C]
+        case GTEQ => q.filter(t => column(t)  >= v): Query[M, U, C]
+        case GT   => q.filter(t => column(t)  >  v): Query[M, U, C]
       }
+
+    final def apply[M, U, C[_]]
+      (column: M => Rep[Option[T]], v: T, q: Query[M, U, C]): PartialFunction[Comparison, Query[M, U, C]] =
+        optionOps(column, v, q).orElse(otherOps(column, v, q))
   }
-    
-  implicit object WhereString extends WhereBuilder[String, String] {
-    def apply[M,U,C[_]](column: M => Rep[String], cmp: Comparison, v: String, q: Query[M,U,C]): Option[Query[M,U,C]] =
-      cmp match {
-        case EQ   => Some(q.filter(t => column(t) === v))
-        case NEQ  => Some(q.filter(t => column(t) =!= v))
-        case LTEQ => Some(q.filter(t => column(t)  <= v))
-        case LT   => Some(q.filter(t => column(t)  <  v))
-        case GTEQ => Some(q.filter(t => column(t)  >= v))
-        case GT   => Some(q.filter(t => column(t)  >  v))
-        case LIKE => Some(q.filter(t => column(t) like v))
-        case IN   => None
+
+  class SeqWhereBuilder[T: BaseTypedType] extends WhereBuilder[T, Seq[T]] {
+    def otherOps[M, U, C[_]]
+      (column: M => Rep[T], v: Seq[T], q: Query[M, U, C]): PartialFunction[Comparison, Query[M, U, C]] =
+        PartialFunction.empty
+
+    private[this] def seqOps[M, U, C[_]]
+      (column: M => Rep[T], v: Seq[T], q: Query[M, U, C]): PartialFunction[Comparison, Query[M, U, C]] = {
+        case IN => q.filter(t => column(t) inSetBind v)
+      }
+
+    final def apply[M, U, C[_]]
+      (column: M => Rep[T], v: Seq[T], q: Query[M, U, C]): PartialFunction[Comparison, Query[M, U, C]] =
+        seqOps(column, v, q).orElse(otherOps(column, v, q))
+  }
+
+  object WhereBuilder extends LowPriorityWhereBuilderInstances {
+    implicit val stringWhereBuilder: WhereBuilder[String, String] = new SameTypeWhereBuilder[String] {
+      override def otherOps[M, U, C[_]]
+        (column: M => Rep[String], v: String, q: Query[M, U, C]): PartialFunction[Comparison, Query[M, U, C]] = {
+          case LIKE => q.filter(t => column(t) like v)
+        }
     }
+
+    implicit val stringOptionWhereBuilder: WhereBuilder[Option[String], String] =
+      new OptionWhereBuilder[String] {
+        override def otherOps[M, U, C[_]]
+          (column: M => Rep[Option[String]], v: String, q: Query[M, U, C]): PartialFunction[Comparison, Query[M, U, C]] = {
+            case LIKE => q.filter(t => column(t) like v)
+          }
+    }
+  }
+
+  class LowPriorityWhereBuilderInstances {
+    implicit def anyWhereBuilder[T: BaseTypedType]: WhereBuilder[T, T] = new SameTypeWhereBuilder[T]
+    implicit def anyOptionWhereBuilder[T: BaseTypedType]: WhereBuilder[Option[T], T] = new OptionWhereBuilder[T]
+    implicit def anySeqWhereBuilder[T: BaseTypedType]: WhereBuilder[T, Seq[T]] = new SeqWhereBuilder[T]
   }
 
   // TODO: Instant, UUID, Boolean, or whatever types we are interested in

--- a/src/main/scala/main.scala
+++ b/src/main/scala/main.scala
@@ -13,14 +13,15 @@ object Example extends App {
 
   final case class Message(
     sender:  String,
-    content: String,
+    content: Option[String],
     id:      Long = 0L)
 
   def freshTestData = Seq(
-    Message("Dave", "Hello, HAL. Do you read me, HAL?"),
-    Message("HAL",  "Affirmative, Dave. I read you."),
-    Message("Dave", "Open the pod bay doors, HAL."),
-    Message("HAL",  "I'm sorry, Dave. I'm afraid I can't do that.")
+    Message("Dave", Some("Hello, HAL. Do you read me, HAL?")),
+    Message("HAL",  Some("Affirmative, Dave. I read you.")),
+    Message("Dave", Some("Open the pod bay doors, HAL.")),
+    Message("HAL",  Some("I'm sorry, Dave. I'm afraid I can't do that.")),
+    Message("Dave", None)
   )
 
   final class MessageTable(tag: Tag)
@@ -28,7 +29,7 @@ object Example extends App {
 
     def id      = column[Long]("id", O.PrimaryKey, O.AutoInc)
     def sender  = column[String]("sender")
-    def content = column[String]("content")
+    def content = column[Option[String]]("content")
 
     def * = (sender, content, id) <> (Message.tupled, Message.unapply)
   }
@@ -55,6 +56,7 @@ object Example extends App {
   val query2 = LIKE.filter(value, messages)(_.id)       // None (LIKE on a LONG not supported)
   val query3 = LIKE.filter("Dave%", messages)(_.sender) // ok
   val query4 = IN.filter(List(1L, 3L), messages)(_.id)  // ok 
+  val query5 = LIKE.filter("Affirmative%", messages)(_.content) // ok
 
   query4 match {
     case Some(q) =>


### PR DESCRIPTION
This change provides reasonable `WhereBuilder[A, A]`, `WhereBuilder[A, Seq[A]]`, and `WhereBuilder[Option[A], A]` instances for any `A` with a Slick `BaseTypedType` instance, and makes it easier to define custom instances for e.g. strings, where `LIKE` is available.
